### PR TITLE
apps: Include Ungoogled Chromium and it's Trichrome WebView provider.

### DIFF
--- a/build/apps.mk
+++ b/build/apps.mk
@@ -30,3 +30,10 @@ PRODUCT_PACKAGES += \
 # Wallpapers
 PRODUCT_PACKAGES += \
     ProtonWallpaperStub \
+    
+# Browser and WebView
+PRODUCT_PACKAGES += \
+    TrichromeLibrary \
+    TrichromeChrome \
+    TrichromeWebView \
+    SystemWebView \


### PR DESCRIPTION
Unfortunately, arm and x86 do not have TriChrome builds of Ungoogled
Chromium's WebView so we resort to the old WebView implementation there.